### PR TITLE
Basic localization support

### DIFF
--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -5,11 +5,18 @@ namespace App\Models;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Model;
 use ScoutElastic\Searchable;
+use Spatie\Translatable\HasTranslations;
 
 class Building extends Model
 {
     use CrudTrait;
     use Searchable;
+    use HasTranslations;
+
+    public $translatable = [
+        'title',
+        'description',
+    ];
 
     protected $indexConfigurator = \App\Elasticsearch\BuildingsIndexConfigurator::class;
 

--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\SearchableWithTranslations;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Model;
 use ScoutElastic\Searchable;
@@ -12,6 +13,7 @@ class Building extends Model
     use CrudTrait;
     use Searchable;
     use HasTranslations;
+    use SearchableWithTranslations;
 
     public $translatable = [
         'title',
@@ -122,6 +124,11 @@ class Building extends Model
         $tags[] = $this->location_city;
         $tags[] = $this->project_duration_dates;
         return $tags;
+    }
+
+    public function toSearchableArray()
+    {
+        return $this->toSearchableArrayWithTranslations();
     }
 
     private function makeArray($str, $delimiter = ',')

--- a/app/Traits/SearchableWithTranslations.php
+++ b/app/Traits/SearchableWithTranslations.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Traits;
+
+trait SearchableWithTranslations
+{
+    /*
+        Turns translatable JSON attributes into simple text attributes for default locale.
+        Adds all translations as extra objects.
+    */
+    public function toSearchableArrayWithTranslations()
+    {
+        $array = $this->toArray();
+
+        // Use default locale in top-level attributes
+        foreach($this->getTranslatableAttributes() as $translatable) {
+            $array[$translatable] = $this->$translatable;
+        }
+
+        // Store all translations in separate objects within the document
+        $translations = $this->getTranslations();
+        foreach(array_keys($translations) as $attribute) {
+            $attributeTranslations = $translations[$attribute];
+
+            foreach(array_keys($attributeTranslations) as $locale) {
+                $array[$locale][$attribute] = $translations[$attribute][$locale];
+            }
+        }
+
+        return $array;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^2.0",
         "lorisleiva/laravel-deployer": "^0.3.0",
-        "spatie/laravel-sluggable": "^2.2"
+        "spatie/laravel-sluggable": "^2.2",
+        "spatie/laravel-translatable": "^4.3"
     },
     "require-dev": {
         "backpack/generators": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1db6fcba273787eae197063437a9f0b",
+    "content-hash": "1251fab5b9fa54a840b339968d18cb0c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3824,6 +3824,84 @@
                 }
             ],
             "time": "2020-04-06T14:31:18+00:00"
+        },
+        {
+            "name": "spatie/laravel-translatable",
+            "version": "4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-translatable.git",
+                "reference": "c15b457ddce4ccaf174de652780647cb086a77a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-translatable/zipball/c15b457ddce4ccaf174de652780647cb086a77a5",
+                "reference": "c15b457ddce4ccaf174de652780647cb086a77a5",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "~5.8.0|^6.0|^7.0",
+                "illuminate/support": "~5.8.0|^6.0|^7.0",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3",
+                "orchestra/testbench": "~3.8.0|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Translatable\\TranslatableServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Translatable\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Mohamed Said",
+                    "email": "theMohamedSaid@gmail.com",
+                    "role": "Original idea"
+                }
+            ],
+            "description": "A trait to make an Eloquent model hold translations",
+            "homepage": "https://github.com/spatie/laravel-translatable",
+            "keywords": [
+                "eloquent",
+                "i8n",
+                "laravel-translatable",
+                "model",
+                "multilingual",
+                "spatie",
+                "translate"
+            ],
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-04-30T10:01:26+00:00"
         },
         {
             "name": "studio-42/elfinder",

--- a/config/translatable.php
+++ b/config/translatable.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+
+    /*
+     * If a translation has not been set for a given locale, use this locale instead.
+     */
+    //TODO this file can be deleted after REGARCH-18 is complete and we can set app fallback_locale to 'sk'
+    'fallback_locale' => 'sk',
+];

--- a/database/migrations/2020_05_15_140907_make_buildings_translatable.php
+++ b/database/migrations/2020_05_15_140907_make_buildings_translatable.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class MakeBuildingsTranslatable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('buildings', function ($table) {
+            $table->json('title_json')->after('title');
+            $table->json('description_json')->nullable()->after('description');
+
+            $table->dropColumn('title');
+            $table->dropColumn('description');
+        });
+
+        Schema::table('buildings', function ($table) {
+            $table->renameColumn('title_json', 'title');
+            $table->renameColumn('description_json', 'description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('buildings', function ($table) {
+            $table->string('title')->nullable()->change();
+            $table->string('description')->nullable()->change();
+        });
+    }
+}


### PR DESCRIPTION
So far only for Building `title` and `description` but the "infrastructure" is in place

Right now, the document in index looks like this: 
![image](https://user-images.githubusercontent.com/1374745/82055715-36c5ab00-96c1-11ea-9475-b6c4e2002e6e.png)

i.e
* The default locale (sk) is in top-level object and also duplicated under `sk` object
* If we leave the search queries as it is, both en and sk translations are being queried

@igor-kamil what do you think about this?

