### PR TITLE
REGARCH-97 projects

### DIFF
--- a/app/Http/Controllers/Admin/CollectionCrudController.php
+++ b/app/Http/Controllers/Admin/CollectionCrudController.php
@@ -44,6 +44,10 @@ class CollectionCrudController extends CrudController
         $this->crud->addFields([
             'title',
             [
+                'type' => 'relationship',
+                'name'  => 'project_id',
+            ],
+            [
                 'name' => 'slug',
                 'label' => 'Slug (URL)',
                 'type' => 'text',

--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Requests\ProjectRequest;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+/**
+ * Class ProjectCrudController
+ * @package App\Http\Controllers\Admin
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ */
+class ProjectCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation { update as traitUpdate; }
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ShowOperation;
+
+    public function setup()
+    {
+        $this->crud->setModel('App\Models\Project');
+        $this->crud->setRoute(config('backpack.base.route_prefix') . '/projects');
+        $this->crud->setEntityNameStrings('project', 'projects');
+
+        $this->crud->setColumns([
+            [
+                'name' => 'title',
+                'type' => 'article',
+            ],
+            [
+                'name' => 'published',
+                'type' => 'published_at',
+            ]
+        ]);
+
+        $this->crud->addFields([
+            [
+                'name' => 'title',
+                'type' => 'text',
+            ],
+            [
+                'name' => 'slug',
+                'label' => 'Slug (URL)',
+                'type' => 'text',
+                'hint' => 'Will be automatically generated from your title, if left empty.'
+            ],
+            [
+                'name'      => 'images',
+                'type'      => 'upload_multiple_media',
+                'upload'    => true,
+            ],
+            [
+                'name' => 'content',
+                'type' => 'tinymce',
+                'options' => [
+                    'entity_encoding' => 'raw',
+                    'height' => 480,
+                    'plugins' => 'image,link,media,anchor,fullscreen',
+                    'toolbar' => 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | outdent indent | fullscreen'
+                ]
+            ],
+            [
+                'name' => 'published_at',
+                'type' => 'datetime_picker',
+                'datetime_picker_options' => [
+                    'language' => 'sk',
+                    'showClear' => true,
+                    'stepping' => 30,
+                ],
+                'wrapper'   => [
+                    'class' => 'col-sm-8 col-md-6 form-group',
+                ],
+            ],
+        ]);
+    }
+
+    public function update()
+    {
+        $response = $this->traitUpdate();
+
+        // Remove media marked for deletion
+        $this->crud->getCurrentEntry()->getMedia()
+            ->whereIn('id', $this->crud->getRequest()->input('clear_images'))
+            ->each(fn ($media) => $media->delete());
+
+        return $response;
+    }
+
+    protected function setupCreateOperation()
+    {
+        $this->crud->setValidation(ProjectRequest::class);
+    }
+
+    protected function setupUpdateOperation()
+    {
+        $this->setupCreateOperation();
+    }
+}

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Project;
+
+class ProjectController extends Controller
+{
+    public function index(Request $request)
+    {
+        $projects = Project::published()->paginate(10);
+        return view('projects.index', compact('projects'));
+    }
+
+    public function show(Project $project)
+    {
+        return view('projects.show', compact('project'));
+    }
+}

--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\Request;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProjectRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        // only allow updates if the user is logged in
+        return backpack_auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|min:2|max:255',
+            'content' => 'required',
+        ];
+    }
+
+    /**
+     * Get the validation attributes that apply to the request.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the validation messages that apply to the request.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -3,11 +3,11 @@
 namespace App\Models;
 
 use App\Traits\Publishable;
+use App\Traits\HasImagesAccessor;
 use App\Traits\HasNavigationHeadings;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\UploadedFile;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Sluggable\HasSlug;
@@ -15,7 +15,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class Article extends Model implements HasMedia
 {
-    use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings;
+    use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings, HasImagesAccessor;
 
     protected $guarded = ['id'];
     protected $dates = ['published_at'];
@@ -24,21 +24,6 @@ class Article extends Model implements HasMedia
     public function getCoverImageTagAttribute()
     {
         return $this->getFirstMedia()->img();
-    }
-
-    public function getImagesAttribute()
-    {
-        return $this->getMedia();
-    }
-
-    public function setImagesAttribute($uploaded_files)
-    {
-        collect($uploaded_files)
-            ->filter() // Ignore nulls
-            ->each(fn (UploadedFile $file) => $this
-                ->addMedia($file)
-                ->toMediaCollection()
-            );
     }
 
     public function getRouteKeyName()

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -21,11 +21,6 @@ class Article extends Model implements HasMedia
     protected $dates = ['published_at'];
     protected $translatable = ['title', 'content'];
 
-    public function getCoverImageTagAttribute()
-    {
-        return $this->getFirstMedia()->img();
-    }
-
     public function getRouteKeyName()
     {
         return 'slug';

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -26,4 +26,9 @@ class Collection extends Model
     {
         return $this->belongsToMany('App\Models\Building')->withPivot('position')->orderBy('position');
     }
+
+    public function project()
+    {
+        return $this->belongsTo('App\Models\Project');
+    }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Publishable;
+use App\Traits\HasNavigationHeadings;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\Sluggable\HasSlug;
+use Spatie\Sluggable\SlugOptions;
+
+class Project extends Model implements HasMedia
+{
+    use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings;
+
+    protected $guarded = ['id'];
+    protected $dates = ['published_at'];
+    protected $translatable = ['title', 'content'];
+
+    public function getCoverImageTagAttribute()
+    {
+        return $this->getFirstMedia()->img();
+    }
+
+    public function getImagesAttribute()
+    {
+        return $this->getMedia();
+    }
+
+    public function setImagesAttribute($uploaded_files)
+    {
+        collect($uploaded_files)
+            ->filter() // Ignore nulls
+            ->each(fn (UploadedFile $file) => $this
+                ->addMedia($file)
+                ->toMediaCollection()
+            );
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('title')
+            ->saveSlugsTo('slug');
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this
+            ->addMediaCollection('default')
+            ->withResponsiveImages();
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -3,11 +3,11 @@
 namespace App\Models;
 
 use App\Traits\Publishable;
+use App\Traits\HasImagesAccessor;
 use App\Traits\HasNavigationHeadings;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\UploadedFile;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Sluggable\HasSlug;
@@ -15,31 +15,11 @@ use Spatie\Sluggable\SlugOptions;
 
 class Project extends Model implements HasMedia
 {
-    use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings;
+    use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings, HasImagesAccessor;
 
     protected $guarded = ['id'];
     protected $dates = ['published_at'];
     protected $translatable = ['title', 'content'];
-
-    public function getCoverImageTagAttribute()
-    {
-        return $this->getFirstMedia()->img();
-    }
-
-    public function getImagesAttribute()
-    {
-        return $this->getMedia();
-    }
-
-    public function setImagesAttribute($uploaded_files)
-    {
-        collect($uploaded_files)
-            ->filter() // Ignore nulls
-            ->each(fn (UploadedFile $file) => $this
-                ->addMedia($file)
-                ->toMediaCollection()
-            );
-    }
 
     public function getRouteKeyName()
     {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -21,9 +21,9 @@ class Project extends Model implements HasMedia
     protected $dates = ['published_at'];
     protected $translatable = ['title', 'content'];
 
-    public function getCoverImageTagAttribute()
+    public function collection()
     {
-        return $this->getFirstMedia()->img();
+        return $this->hasOne('App\Models\Collection');
     }
 
     public function getRouteKeyName()

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -21,6 +21,11 @@ class Project extends Model implements HasMedia
     protected $dates = ['published_at'];
     protected $translatable = ['title', 'content'];
 
+    public function getCoverImageTagAttribute()
+    {
+        return $this->getFirstMedia()->img();
+    }
+
     public function getRouteKeyName()
     {
         return 'slug';

--- a/app/Traits/HasImagesAccessor.php
+++ b/app/Traits/HasImagesAccessor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Http\UploadedFile;
+
+trait HasImagesAccessor
+{
+    public function getImagesAttribute()
+    {
+        return $this->getMedia();
+    }
+
+    public function setImagesAttribute($uploaded_files)
+    {
+        collect($uploaded_files)
+            ->filter() // Ignore nulls
+            ->each(fn (UploadedFile $file) => $this
+                ->addMedia($file)
+                ->toMediaCollection()
+            );
+    }
+}

--- a/app/Traits/HasNavigationHeadings.php
+++ b/app/Traits/HasNavigationHeadings.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Str;
+use PHPHtmlParser\Dom;
+
+trait HasNavigationHeadings
+{
+    public function getContentHtmlAttribute()
+    {
+        $dom = new Dom;
+        $dom->loadStr($this->content);
+
+        foreach($this->findHeadingsForNavigation($dom) as $index => $heading) {
+            $heading->setAttribute('id', Str::slug($heading->text) . "-$index");
+        }
+
+        return $dom;
+    }
+
+    public function getNavigationHeadingsAttribute()
+    {
+        $dom = new Dom;
+        $dom->loadStr($this->content);
+
+        return collect($this->findHeadingsForNavigation($dom))
+            ->map(fn ($heading, $index) => (object) [
+                'text' => $heading->text,
+                'href' => '#' . Str::slug($heading->text) . "-$index",
+            ]);
+    }
+
+    private function findHeadingsForNavigation($dom)
+    {
+        return $dom->find('h1,h2,h3');
+    }
+}

--- a/database/migrations/2020_08_20_121046_create_projects_table.php
+++ b/database/migrations/2020_08_20_121046_create_projects_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+
+            $table->json('title');
+            $table->string('slug')->unique();
+            $table->json('content')->nullable();
+            $table->timestamp('published_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('projects');
+    }
+}

--- a/database/migrations/2020_08_20_131722_add_project_to_collections.php
+++ b/database/migrations/2020_08_20_131722_add_project_to_collections.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProjectToCollections extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('collections', function (Blueprint $table) {
+            $table->foreignId('project_id')->after('id')->nullable()->constrained();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('collections', function (Blueprint $table) {
+            $table->dropForeign(['project_id']);
+            $table->dropColumn('project_id');
+        });
+    }
+}

--- a/resources/lang/en/header.php
+++ b/resources/lang/en/header.php
@@ -11,6 +11,7 @@ return [
         'department' => 'Department of Architecture',
         'department_page_title' => 'Department of Architecture',
         'news' => 'News',
+        'projects' => 'Projects',
         'publications' => 'Publications',
     ]
 ];

--- a/resources/lang/sk/header.php
+++ b/resources/lang/sk/header.php
@@ -10,7 +10,7 @@ return [
         'index' => 'oA',
         'department' => 'Oddelenie architektúry HÚ&nbsp;SAV',
         'department_page_title' => 'Oddelenie architektúry HÚ SAV', // Re-define without HTML tags
-        'news' => 'Novinky',
+        'projects' => 'Projekty',
         'publications' => 'Publikácie',
     ]
 ];

--- a/resources/lang/sk/header.php
+++ b/resources/lang/sk/header.php
@@ -10,6 +10,7 @@ return [
         'index' => 'oA',
         'department' => 'Oddelenie architektúry HÚ&nbsp;SAV',
         'department_page_title' => 'Oddelenie architektúry HÚ SAV', // Re-define without HTML tags
+        'news' => 'Novinky',
         'projects' => 'Projekty',
         'publications' => 'Publikácie',
     ]

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -70,6 +70,7 @@
             <nav class="nav nav-justified sub-nav bg-light collapse navbar-collapse align-items-stretch">
                 <a class="nav-item d-sm-flex align-items-center justify-content-center py-3 ls-3 border-bl nav-link {{ Route::is('about.department') ? 'active' : '' }}" href="{{ route('about.department') }}">{!! __('header.about.department') !!}</a>
                 <a class="nav-item d-sm-flex align-items-center justify-content-center py-3 ls-3 border-bl nav-link {{ Route::is('about.articles.*') ? 'active' : '' }}" href="{{ route('about.articles.index') }}">{{ __('header.about.news') }}</a>
+                <a class="nav-item d-sm-flex align-items-center justify-content-center py-3 ls-3 border-bl nav-link {{ Route::is('about.projects.*') ? 'active' : '' }}" href="{{ route('about.projects.index') }}">{{ __('header.about.projects') }}</a>
                 <a class="nav-item d-sm-flex align-items-center justify-content-center py-3 ls-3 border-bl nav-link {{ Route::is('about.publications') ? 'active' : '' }}" href="{{ route('about.publications') }}">{{ __('header.about.publications') }}</a>
             </nav>
         </div>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -57,10 +57,10 @@
         <div class="col-md-12">
             {{-- fields bellow should be taken from "featured" collections and translated within them --}}
             <nav class="nav nav-justified sub-nav collapse navbar-collapse">
-                <a class="nav-item py-3 ls-3 border-bl nav-link" href="#">MoMoWo</a>
-                <a class="nav-item py-3 ls-3 border-bl text-uppercase nav-link" href="#">ATRIUM</a>
-                <a class="nav-item py-3 ls-3 border-bl nav-link" href="#">ŠUR</a>
-                <a class="nav-item py-3 ls-3 border-bl nav-link" href="#">Do.co,mo.mo</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'momowo' ? 'active' : '' }}" href="{{ route('about.projects.show', 'momowo') }}">MoMoWo</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'atrium' ? 'active' : '' }}" href="{{ route('about.projects.show', 'atrium') }}">ATRIUM</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'sur' ? 'active' : '' }}" href="{{ route('about.projects.show', 'sur') }}">ŠUR</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'docomomo' ? 'active' : '' }}" href="{{ route('about.projects.show', 'docomomo') }}">Do.co,mo.mo</a>
             </nav>
         </div>
     </div>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -57,10 +57,10 @@
         <div class="col-md-12">
             {{-- fields bellow should be taken from "featured" collections and translated within them --}}
             <nav class="nav nav-justified sub-nav collapse navbar-collapse">
-                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'momowo' ? 'active' : '' }}" href="{{ route('about.projects.show', 'momowo') }}">MoMoWo</a>
-                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'atrium' ? 'active' : '' }}" href="{{ route('about.projects.show', 'atrium') }}">ATRIUM</a>
-                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'sur' ? 'active' : '' }}" href="{{ route('about.projects.show', 'sur') }}">ŠUR</a>
-                <a class="nav-item py-3 ls-3 border-bl nav-link {{ isset($project) && $project->slug == 'docomomo' ? 'active' : '' }}" href="{{ route('about.projects.show', 'docomomo') }}">Do.co,mo.mo</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ Route::is('about.projects.show') && $project->slug == 'momowo' ? 'active' : '' }}" href="{{ route('about.projects.show', 'momowo') }}">MoMoWo</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ Route::is('about.projects.show') && $project->slug == 'atrium' ? 'active' : '' }}" href="{{ route('about.projects.show', 'atrium') }}">ATRIUM</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ Route::is('about.projects.show') && $project->slug == 'sur' ? 'active' : '' }}" href="{{ route('about.projects.show', 'sur') }}">ŠUR</a>
+                <a class="nav-item py-3 ls-3 border-bl nav-link {{ Route::is('about.projects.show') && $project->slug == 'docomomo' ? 'active' : '' }}" href="{{ route('about.projects.show', 'docomomo') }}">Do.co,mo.mo</a>
             </nav>
         </div>
     </div>

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+@section('title', __('header.about.projects'))
+
+@section('content')
+@include('components.header')
+
+<div class="container-fluid my-lg-7">
+    @foreach($projects as $project)
+    <div class="row border-bottom py-3">
+        <div class="col-lg-6 order-2 order-lg-1">
+            <h6 class="mb-4 font-weight-bold"><a href="{{ route('about.projects.show', $project) }}" class="link-no-underline">{{ $project->title }}</a></h6>
+            {{ Str::words(strip_tags($project->content), 100) }}
+        </div>
+        <div class="col-lg-6 order-1 order-lg-2 mb-4 mb-lg-0 ">
+            @if($project->hasMedia())
+                {{ $project->getFirstMedia()->img()->attributes(['class' => 'w-6rem w-sm-8rem ', 'width' => 'auto']) }}
+            @endif
+        </div>
+    </div>
+    @endforeach
+    <div class="row">
+        <div class="col text-center">
+            {{ $projects->withQueryString()->links() }}
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.app')
+@section('title', $project->title)
+
+@section('content')
+@include('components.header')
+
+<div class="container-fluid my-lg-7">
+    <div class="row border-top pt-3">
+        <div class="col-lg-6 offset-lg-3">
+            <h2 class="mb-2 ls-2">{{ $project->title }}</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-3 pt-4 lg-pt-0">
+            <ul class="nav flex-column">
+                @foreach($project->navigation_headings as $heading)
+                <li class="nav-item pb-3">
+                 <a href="{{ $heading->href }}"><h3>{{ $heading->text }}</h3></a>
+                </li>
+                @endforeach
+            </ul>
+        </div>
+        <div class="col-lg-6 pt-4">
+            {!! $project->contentHtml !!}
+        </div>
+        <div class="col-lg-3">
+            @include('components.gallery-carousel', [
+                'images' => $project->getMedia(),
+            ])
+        </div>
+    </div>
+</div>
+
+
+@endsection

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -1,7 +1,8 @@
 <!-- This file is used to store sidebar items, starting with Backpack\Base 0.9.0 -->
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('dashboard') }}"><i class="la la-home nav-icon"></i> {{ trans('backpack::base.dashboard') }}</a></li>
-<li class='nav-item'><a class='nav-link' href='{{ backpack_url('articles') }}'><i class='nav-icon la la-newspaper-o'></i> Articles</a></li>
 <li class='nav-item'><a class='nav-link' href='{{ backpack_url('collections') }}'><i class='nav-icon la la-layer-group'></i> Collections</a></li>
+<li class='nav-item'><a class='nav-link' href='{{ backpack_url('articles') }}'><i class='nav-icon la la-newspaper-o'></i> Articles</a></li>
+<li class='nav-item'><a class='nav-link' href='{{ backpack_url('projects') }}'><i class='nav-icon la la-fire'></i> Projects</a></li>
 <li class='nav-item'><a class='nav-link' href='{{ backpack_url('publications') }}'><i class='nav-icon la la-book'></i> Publications</a></li>
 
 <li class="nav-title">Naimportované</li>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -20,4 +20,5 @@ Route::group([
     Route::crud('publications', 'PublicationCrudController');
     Route::crud('articles', 'ArticleCrudController');
     Route::crud('collections', 'CollectionCrudController');
+    Route::crud('projects', 'ProjectCrudController');
 }); // this should be the absolute last line of this file

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,8 @@ Route::group(['prefix' => LaravelLocalization::setLocale()], function()
         Route::view('/oddelenie-architektury', 'department')->name('department');
         Route::resource('novinky', 'ArticleController')->names('articles')
             ->parameter('novinky', 'article');
+        Route::resource('projekty', 'ProjectController')->names('projects')
+            ->parameter('projekty', 'project');
         Route::get('publikacie', 'PublicationController@index')->name('publications');
     });
 });


### PR DESCRIPTION
* Created a new Projects entity based on Article. 
* Collections have an optional link to Projects
* second-line links to MoMoWo, DOCOMOMO etc point to the project pages (which will, in turn, link to the collections)

The navigation is implemented naively, meaning that /projekty/docomomo will match three menu items... :
![image](https://user-images.githubusercontent.com/1374745/90775587-4aecfa00-e2f9-11ea-8279-f011e68753c8.png)

@igor-kamil I've also tried matching the selected projects with a root url (e.g. `/docomomo`) which would work around that problem. Let me know if you'd prefer it...