### PR TITLE
Feature/regarch 114 timeline mobile

### DIFF
--- a/resources/js/components/timeline.js
+++ b/resources/js/components/timeline.js
@@ -3,6 +3,16 @@ import noUiSlider from 'nouislider';
 $(document).ready(function(){
     if($('#year_from').length > 0) {
 
+        function filterPips(value, type) {
+            if (
+                ($(window).width() < 768) &&
+                ($('#year_until').data('max') - $('#year_from').data('min') >= 70)
+            ) {
+                return value % 20 ? 0 : 1;
+            }
+            return type;
+        }
+
         var timeline = noUiSlider.create($('#years')[0], {
             start: [$("#year_from").val(), $("#year_until").val()],
             connect: true,
@@ -15,6 +25,7 @@ $(document).ready(function(){
             pips: {
                 mode: 'steps',
                 stepped: true,
+                filter: filterPips,
                 density: 10
             },
             format: {

--- a/resources/views/architects/index.blade.php
+++ b/resources/views/architects/index.blade.php
@@ -23,7 +23,7 @@
             </div>
         </div>
         <div class="row no-gutters">
-            <div class="col-12 py-5 mt-md-0">
+            <div class="col-12 py-2 py-md-3 py-lg-5 mt-md-0">
                 @include('components.timeline', [
                     'year_from' => request('year_from', $filter_values['year_min']),
                     'year_until' => request('year_until', $filter_values['year_max']),

--- a/resources/views/building/index.blade.php
+++ b/resources/views/building/index.blade.php
@@ -24,7 +24,7 @@
                 </div>
 
                 <div class="row no-gutters">
-                    <div class="col-12 py-5 mt-md-0">
+                    <div class="col-12 py-2 py-md-3 py-lg-5 mt-md-0">
                         @include('components.timeline', [
                             'year_from' => request('year_from', $filter_values['year_min']),
                             'year_until' => request('year_until', $filter_values['year_max']),


### PR DESCRIPTION
skip every second pip on small screens if there is too many of them (distance between `min` and `max` is >= 70 years) then display only the even ones

@eronisko this is just an idea how to make it looks better. maybe you comes with better idea. 

![Screenshot 2020-08-25 at 13 49 39](https://user-images.githubusercontent.com/2682941/91171065-2b2f4a80-e6da-11ea-938c-509b0c970925.png)
