### PR TITLE
Terminate Horizon with a 'sudo'

### DIFF
--- a/config/deploy.php
+++ b/config/deploy.php
@@ -63,7 +63,7 @@ return [
             'artisan:config:cache',
             'artisan:migrate',
             'elastic:migrate',
-            'artisan:horizon:terminate',
+            'sudo:artisan:horizon:terminate',
         ],
 
         // Deployment is done and live
@@ -157,7 +157,7 @@ return [
     */
 
     'include' => [
-        'deployer/elastic.php',
+        'deployer/custom.php',
     ],
 
     /*

--- a/deployer/custom.php
+++ b/deployer/custom.php
@@ -7,3 +7,7 @@ task('elastic:migrate', function () {
     run('{{bin/php}} {{release_path}}/artisan regarch:elastic:migrate -q');
 });
 
+desc('Terminate horizon as user www-data');
+task('sudo:artisan:horizon:terminate', function () {
+    run('sudo -u www-data {{bin/php}} {{release_path}}/artisan horizon:terminate');
+});


### PR DESCRIPTION
Because Horizon runs as `www-data` user, we have to use `sudo` to TERM that process.