### PR TITLE
Feature/regarch 139 newsticker toggle

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,10 +1,11 @@
 require('./bootstrap');
-require('./components/filters');
-require('./components/buildings-carousel');
-require('./components/gallery-carousel');
 require('./components/building-card');
+require('./components/buildings-carousel');
+require('./components/expandable');
+require('./components/filters');
+require('./components/gallery-carousel');
 require('./components/load-more');
 require('./components/map');
-require('./components/timeline');
-require('./components/expandable');
+require('./components/news-ticker');
 require('./components/search');
+require('./components/timeline');

--- a/resources/js/components/map.js
+++ b/resources/js/components/map.js
@@ -191,7 +191,7 @@ $(document).ready(function(){
 		}
 
 		if(!$('#map').hasClass('hide')) {
-			$.post("/map/hide");
+			$.post( "/settings", {show_map: 'false'});
 			$('#map').fadeOut(300, function(){
 				$('#map').addClass('hide');
 				$('#map-container').removeClass('vh-38');
@@ -199,7 +199,7 @@ $(document).ready(function(){
 			});
 			$('#map-toggle').removeClass('active');
 		} else {
-			$.post("/map/show");
+			$.post( "/settings", {show_map: 'true'});
 			$('#map-toggle').addClass('active');
 			$('#map-container').addClass('vh-38');
 			$('#map').removeClass('hide').fadeIn(300, function(){

--- a/resources/js/components/map.js
+++ b/resources/js/components/map.js
@@ -191,7 +191,7 @@ $(document).ready(function(){
 		}
 
 		if(!$('#map').hasClass('hide')) {
-			$.post( "/settings", {show_map: 'false'});
+			$.post( "/settings", {show_map: false});
 			$('#map').fadeOut(300, function(){
 				$('#map').addClass('hide');
 				$('#map-container').removeClass('vh-38');
@@ -199,7 +199,7 @@ $(document).ready(function(){
 			});
 			$('#map-toggle').removeClass('active');
 		} else {
-			$.post( "/settings", {show_map: 'true'});
+			$.post( "/settings", {show_map: true});
 			$('#map-toggle').addClass('active');
 			$('#map-container').addClass('vh-38');
 			$('#map').removeClass('hide').fadeIn(300, function(){

--- a/resources/js/components/news-ticker.js
+++ b/resources/js/components/news-ticker.js
@@ -1,0 +1,8 @@
+$(document).ready(function(){
+    $('#hide-news').on('click', function(e) {
+        e.preventDefault();
+        $.post( "/toggle-newsticker", function( data ) {
+          $('#news').fadeOut();
+        });
+    })
+});

--- a/resources/js/components/news-ticker.js
+++ b/resources/js/components/news-ticker.js
@@ -1,8 +1,8 @@
 $(document).ready(function(){
     $('#hide-news').on('click', function(e) {
         e.preventDefault();
-        $.post( "/toggle-newsticker", function( data ) {
-          $('#news').fadeOut();
+        $.post( "/settings", {hide_news_ticker: true}, function( result ) {
+            $('#news').fadeOut();
         });
     })
 });

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -40,3 +40,4 @@
 @import 'components/langswitch';
 @import 'components/load-more';
 @import 'components/map';
+@import 'components/news-ticker';

--- a/resources/sass/components/news-ticker.scss
+++ b/resources/sass/components/news-ticker.scss
@@ -1,4 +1,5 @@
 #news {
+    display: flex;
     line-height: 1rem;
 
     marquee {

--- a/resources/sass/components/news-ticker.scss
+++ b/resources/sass/components/news-ticker.scss
@@ -1,0 +1,8 @@
+#news {
+    line-height: 1rem;
+
+    marquee {
+        // mask-image: linear-gradient(to right, rgba(0,0,0,0) 0, rgba(0,0,0,1) 2rem); // can't make it works
+        -webkit-mask-image: -webkit-linear-gradient(right, rgba(0,0,0,0) 0, rgba(0,0,0,1) 2rem);
+    }
+}

--- a/resources/sass/components/news-ticker.scss
+++ b/resources/sass/components/news-ticker.scss
@@ -3,7 +3,26 @@
     line-height: 1rem;
 
     marquee {
-        // mask-image: linear-gradient(to right, rgba(0,0,0,0) 0, rgba(0,0,0,1) 2rem); // can't make it works
-        -webkit-mask-image: -webkit-linear-gradient(right, rgba(0,0,0,0) 0, rgba(0,0,0,1) 2rem);
+        position: relative;
+
+        &:before, &:after {
+            content: '';
+            position: absolute;
+            display: block;
+            width: 2rem;
+            height: 100%;
+            z-index: 1;
+            top: 0;
+        }
+
+        &:before {
+            left: 0;
+            background: linear-gradient(to right, $light 0%, transparent 100%);
+        }
+
+        &:after {
+            right: 0;
+            background: linear-gradient(to left, $light 0%, transparent 100%);
+        }
     }
 }

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,4 +1,7 @@
-@include('components.news-ticker')
+@if (!session('hide-newsticker', false))
+    @include('components.news-ticker')
+@endif
+
 <div class="container-fluid p-0 navbar-expand-md bg-white" id="header">
     <div class="row no-gutters align-items-stretch">
         <div class="d-none d-md-block col-md-12 col-lg-4 py-3 border-bl text-center align-items-center">

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,4 +1,4 @@
-@if (!session('hide-newsticker', false))
+@if (!(Cookie::get('hide_news_ticker') == 'true'))
     @include('components.news-ticker')
 @endif
 

--- a/resources/views/components/map.blade.php
+++ b/resources/views/components/map.blade.php
@@ -1,7 +1,7 @@
 @php
 $center = $center ?? [19.696058, 48.6737532];
 $zoom = $zoom ?? 6;
-$show_map = session('show_map', true);
+$show_map = (Cookie::get('show_map') == 'true') ? true : false;
 @endphp
 
 <div class="container-fluid p-0 position-relative {{ ($show_map) ? 'vh-38' : '' }}" id="map-container">

--- a/resources/views/components/map.blade.php
+++ b/resources/views/components/map.blade.php
@@ -1,7 +1,7 @@
 @php
 $center = $center ?? [19.696058, 48.6737532];
 $zoom = $zoom ?? 6;
-$show_map = (Cookie::get('show_map') == 'true') ? true : false;
+$show_map = (Cookie::get('show_map') == 'true');
 @endphp
 
 <div class="container-fluid p-0 position-relative {{ ($show_map) ? 'vh-38' : '' }}" id="map-container">

--- a/resources/views/components/news-ticker.blade.php
+++ b/resources/views/components/news-ticker.blade.php
@@ -3,11 +3,12 @@
 @endphp
 
 @if ($articles->count() > 0)
-    <div class="container-fluid p-0 pt-1 bg-light border-bottom" id="news">
+    <div class="container-fluid p-0 pt-1 bg-light border-bottom d-flex" id="news">
         <marquee class="news-scroll py-2 ls-2" behavior="scroll" direction="left" onmouseover="this.stop();" onmouseout="this.start();">
             @foreach ($articles as $article)
                 <a href="{{ route('about.articles.show', $article) }}" class="link-no-underline mr-3">{{ $article->title }}</a>
             @endforeach
         </marquee>
+        <a href="#close" class="d-block icon-close p-2 link-no-underline border-bottom-0"></a>
     </div>
 @endif

--- a/resources/views/components/news-ticker.blade.php
+++ b/resources/views/components/news-ticker.blade.php
@@ -3,12 +3,12 @@
 @endphp
 
 @if ($articles->count() > 0)
-    <div class="container-fluid p-0 pt-1 bg-light border-bottom d-flex" id="news">
+    <div class="container-fluid p-0 pt-1 bg-light border-bottom" id="news">
         <marquee class="news-scroll py-2 ls-2" behavior="scroll" direction="left" onmouseover="this.stop();" onmouseout="this.start();">
             @foreach ($articles as $article)
                 <a href="{{ route('about.articles.show', $article) }}" class="link-no-underline mr-3">{{ $article->title }}</a>
             @endforeach
         </marquee>
-        <a href="#close" class="d-block icon-close p-2 link-no-underline border-bottom-0"></a>
+        <a href="#close" class="d-block icon-close p-2 link-no-underline border-bottom-0" id="hide-news"></a>
     </div>
 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale()], function()
 Route::get('styleguide', 'StyleGuideController@index')->name('styleguide');
 
 Route::post('settings', function(Request $request) {
-    $time = 60 * 1; // in minutes
+    $time = 60; // in minutes
     if ($request->has('hide_news_ticker')) Cookie::queue('hide_news_ticker', $request->input('hide_news_ticker'), $time);
     if ($request->has('show_map')) Cookie::queue('show_map', $request->input('show_map'), $time);
     return response();

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,3 +51,9 @@ Route::post('map/show', function (Request $request) {
     $request->session()->put('show_map', true);
     return response(null, Response::HTTP_OK);
 });
+
+Route::post('toggle-newsticker', function(Request $request) {
+    $hide_newsticker = $request->session()->get('hide-newsticker', false);
+    $request->session()->put('hide-newsticker', !$hide_newsticker);
+    return response(null, Response::HTTP_OK);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,18 +42,10 @@ Route::group(['prefix' => LaravelLocalization::setLocale()], function()
 
 Route::get('styleguide', 'StyleGuideController@index')->name('styleguide');
 
-Route::post('map/hide', function (Request $request) {
-    $request->session()->put('show_map', false);
+Route::post('settings', function(Request $request) {
+    $time = 60 * 1; // in minutes
+    if ($request->has('hide_news_ticker')) Cookie::queue('hide_news_ticker', $request->input('hide_news_ticker'), $time);
+    if ($request->has('show_map')) Cookie::queue('show_map', $request->input('show_map'), $time);
     return response(null, Response::HTTP_OK);
 });
 
-Route::post('map/show', function (Request $request) {
-    $request->session()->put('show_map', true);
-    return response(null, Response::HTTP_OK);
-});
-
-Route::post('toggle-newsticker', function(Request $request) {
-    $hide_newsticker = $request->session()->get('hide-newsticker', false);
-    $request->session()->put('hide-newsticker', !$hide_newsticker);
-    return response(null, Response::HTTP_OK);
-});

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,5 @@ Route::post('settings', function(Request $request) {
     $time = 60 * 1; // in minutes
     if ($request->has('hide_news_ticker')) Cookie::queue('hide_news_ticker', $request->input('hide_news_ticker'), $time);
     if ($request->has('show_map')) Cookie::queue('show_map', $request->input('show_map'), $time);
-    return response(null, Response::HTTP_OK);
+    return response();
 });
-


### PR DESCRIPTION
![Screenshot 2020-10-05 at 23 48 34](https://user-images.githubusercontent.com/2682941/95135828-525f4a00-0765-11eb-9632-c5a2d2ffe9b5.png)


any ideas, how to make it work again (without removing the cookie)? I was thinking about adding link to enable "news-ticker" to footer (when it's off).
another issue is, that I was unable to make the smooth fade/gradient work outside of the webkit browsers... 