### PR TITLE
REGARCH-166: Make $guarded empty for Article and Project

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -17,7 +17,7 @@ class Article extends Model implements HasMedia
 {
     use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings, HasImagesAccessor;
 
-    protected $guarded = ['id'];
+    protected $guarded = [];
     protected $dates = ['published_at'];
     protected $translatable = ['title', 'content'];
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -17,7 +17,7 @@ class Project extends Model implements HasMedia
 {
     use CrudTrait, InteractsWithMedia, HasSlug, HasTranslations, Publishable, HasNavigationHeadings, HasImagesAccessor;
 
-    protected $guarded = ['id'];
+    protected $guarded = [];
     protected $dates = ['published_at'];
     protected $translatable = ['title', 'content'];
 

--- a/app/Traits/HasImagesAccessor.php
+++ b/app/Traits/HasImagesAccessor.php
@@ -4,13 +4,12 @@ namespace App\Traits;
 
 use Illuminate\Http\UploadedFile;
 
+// Note that 'images' attribute must be either added to $fillable
+// or $guarded must be empty ([]) for this trait to work in mass
+// assignment. See https://github.com/laravel/framework/issues/33978
+// for details.
 trait HasImagesAccessor
 {
-    public function initializeHasImagesAccessor()
-    {
-        $this->fillable[] = 'images';
-    }
-
     public function getImagesAttribute()
     {
         return $this->getMedia();


### PR DESCRIPTION
This is due to an issue discussed at
https://github.com/laravel/framework/issues/33978

Mass assignment does not work on "fake"/"virtual" attributes unless
they're explicitly added to $fillable (which we don't use here)